### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -16,7 +16,7 @@ begin	KEYWORD2
 update	KEYWORD2
 setLed	KEYWORD2
 toggleLed	KEYWORD2
-getLed KEYWORD2
+getLed	KEYWORD2
 getTemperature	KEYWORD2
 getLightLevel	KEYWORD2
 isBtn1Pressed	KEYWORD2
@@ -26,7 +26,7 @@ isBtn2Held	KEYWORD2
 playTone	KEYWORD2
 playMelody	KEYWORD2
 stopTone	KEYWORD2
-setScreenBrightness KEYWORD2
+setScreenBrightness	KEYWORD2
 fillScreen	KEYWORD2
 clearScreen	KEYWORD2
 drawRow	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords